### PR TITLE
Use gcc-9 as stable compiler

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "type": "shell",
       "label": "C/C++: g++ build active file",
-      "command": "x86_64-apple-darwin19-g++-10",
+      "command": "g++-9",
       "args": [
         "-std=c++17",
         "-g",

--- a/README.md
+++ b/README.md
@@ -8,13 +8,16 @@ Note that any artifact is not supposed to be committed. This is only a workspace
 
 ## provision
 ### install gcc
-Fetch gcc via homebrew:
+Fetch gcc@9 via homebrew:
 
 ```
-brew install gcc
+brew install gcc@9
 ```
 
-This enables the executable `x86_64-apple-darwin19-g++-10`, on which we depend.
+This enables the executable `/usr/local/bin/g++-9`, on which we depend.
+
+#### Waiver
+Aliasing `g++` to `g++-9` in dotfiles and simply calling `g++` in `tasks.json` do not help. Perhaps `tasks.json` does not load the alias on the fly. Will need to be worked on. However we have fixed the version to 9 at least and are definitely happier than before :)
 
 ### install ac-library
 Fetch [atcoder/ac-library](https://github.com/atcoder/ac-library) and place it in the include path:


### PR DESCRIPTION
Compile task breaks when you upgrade gcc's major version. This is because we have not fixed the gcc version when installing it. Now we are moving to gcc-9 and will be using it as a fixed version.